### PR TITLE
Make sure to respect the --collect-only command-line option.

### DIFF
--- a/pytest_asyncio_concurrent/plugin.py
+++ b/pytest_asyncio_concurrent/plugin.py
@@ -163,6 +163,9 @@ def pytest_runtestloop_handle_async_by_group(session: pytest.Session) -> Generat
 
     result = yield
 
+    if session.config.option.collectonly:
+        return result
+
     for i, group in enumerate(groups):
         nextgroup = groups[i + 1] if i + 1 < len(groups) else None
         ihook.pytest_runtest_protocol_async_group(group=group, nextgroup=nextgroup)


### PR DESCRIPTION
Don't execute the tests in that case.